### PR TITLE
Simplify `Contig` and `GenomeBuild`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ license-file = "LICENSE"
 authors = ["Daniel Danis <daniel.gordon.danis@protonmail.com>"]
 
 [dependencies]
-num-traits = "0.2.19"
+thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 use dabuild::builds::get_grch38_p13;
 
 // Load the build
-let build: GenomeBuild<u32> = get_grch38_p13();
+let build: GenomeBuild = get_grch38_p13();
 
 // Check the basic credentials, such as major assembly and patch version
 assert_eq!(build.id().major_assembly(), "GRCh38");
@@ -21,15 +21,15 @@ assert_eq!(build.id().patch(), Some("p13"));
 let y = build.contig_by_name("Y");
 assert!(y.is_some());
 
-/// ... or GenBank accession ...
+/// ... or by the GenBank accession ...
 let y = build.contig_by_name("CM000686.2");
 assert!(y.is_some());
 
-/// ... or RefSeq accession ...
+/// ... or by the RefSeq accession ...
 let y = build.contig_by_name("NC_000024.10");
 assert!(y.is_some());
 
-/// ... or UCSC identifier.
+/// ... or by the UCSC identifier.
 let y = build.contig_by_name("chrY");
 assert!(y.is_some());
 ```

--- a/src/builds.rs
+++ b/src/builds.rs
@@ -17,7 +17,7 @@
 //! use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! use dabuild::builds::get_grch38_p13;
 //!
-//! let build: GenomeBuild<u32> = get_grch38_p13();
+//! let build: GenomeBuild = get_grch38_p13();
 //! ```
 //!
 //! ## Load from an assembly report
@@ -34,20 +34,19 @@
 //! use std::{fs::File, io::BufReader, str::FromStr};
 //!
 //! let path = "data/GCF_000001635.27_GRCm39_assembly_report.txt";
-//! let build: GenomeBuild<u32> = parse_assembly_report(
+//! let build: GenomeBuild = parse_assembly_report(
 //!         GenomeBuildIdentifier::from_str("GRCm39").expect("Infallible"),
-//!         BufReader::new(File::open(path).expect("File not found")),
+//!         BufReader::new(File::open(path).expect("File should be present and readable")),
 //! ).expect("No I/O or format issues");
 //!
 //! assert_eq!(build.id().major_assembly(), "GRCm39");
 //! ```
 //!
 
-use std::{error::Error, io::BufRead, str::FromStr};
-
-use num_traits::Zero;
-
 use super::{Contig, GenomeBuild, GenomeBuildIdentifier};
+use std::num::ParseIntError;
+use std::{io, io::BufRead};
+use thiserror::Error;
 
 #[allow(non_upper_case_globals)]
 const GRCh37_p13: &[u8] = include_bytes!("data/GCF_000001405.25_GRCh37.p13_assembly_report.tsv");
@@ -59,25 +58,19 @@ const GRCh38_p13: &[u8] = include_bytes!("data/GCF_000001405.39_GRCh38.p13_assem
 /// ## Panics
 ///
 /// If the builtin assembly report cannot be parsed (should not happen).
-pub fn get_grch37_p13<C>() -> GenomeBuild<C>
-where
-    C: FromStr + Zero + PartialOrd,
-{
+pub fn get_grch37_p13() -> GenomeBuild {
     let id = GenomeBuildIdentifier::from(("GRCh37", "p13"));
-    parse_assembly_report(id, GRCh37_p13).expect("Reading builtin GRCh37.p13 assembly report")
+    parse_assembly_report(id, GRCh37_p13).expect("The embedded assembly report for GRCh37.p13 should be valid")
 }
 
 /// Get the *GRCh38.p13* build.
 ///
 /// ## Panics
 ///
-/// If the builtin assembly report cannot be parsed (should not happen).
-pub fn get_grch38_p13<C>() -> GenomeBuild<C>
-where
-    C: FromStr + Zero + PartialOrd,
-{
+/// If the builtin assembly report cannot be parsed (should not really happen).
+pub fn get_grch38_p13() -> GenomeBuild {
     let id = GenomeBuildIdentifier::from(("GRCh38", "p13"));
-    parse_assembly_report(id, GRCh38_p13).expect("Reading builtin GRCh38.p13 assembly report")
+    parse_assembly_report(id, GRCh38_p13).expect("The embedded assembly report for GRCh38.p13 should be valid")
 }
 
 /// Parse an assembly report into a [`GenomeBuild`].
@@ -99,79 +92,113 @@ where
 ///
 /// ## Errors
 ///
-/// The parsing can fail from several reasons:
+/// The parsing can fail from the reasons outlined in [`GenomeAssemblyParseError`].
 ///
-/// * I/O error of the underlying [`BufRead`]
-/// * Missing column `0` (`Sequence-Name`)
-/// * Missing/unparsable column `8` (`Sequence-Length`)
-/// * Sequence length being negative (should not really happen)
-pub fn parse_assembly_report<C, R>(
+pub fn parse_assembly_report<R>(
     id: GenomeBuildIdentifier,
     read: R,
-) -> Result<GenomeBuild<C>, Box<dyn Error>>
+) -> Result<GenomeBuild, GenomeAssemblyParseError>
 where
-    C: FromStr + Zero + PartialOrd,
     R: BufRead,
 {
     let mut contigs = vec![];
 
     for (i, line) in read.lines().enumerate() {
-        // Bail in case of I/O errors.
         let line = line?;
 
-        if line.starts_with("#") {
-            continue;
+        if !line.starts_with("#") {
+            let fields: Vec<_> = line.split("\t").collect();
+            let record = GenomeAssemblyRecord::try_from(fields)
+                .map_err(|e| GenomeAssemblyParseError::AssemblyReportLineParseError(i, e.into()))?;
+            contigs.push(Contig::try_from(record).map_err(|e| {
+                GenomeAssemblyParseError::AssemblyReportLineParseError(i, e.into())
+            })?);
         }
-        let fields: Vec<_> = line.split("\t").collect();
-
-        // Disabling the lint to emphasize accessing the columns with indices.
-        #[allow(clippy::get_first)]
-        let name = if let Some(&name) = fields.get(0) {
-            name
-        } else {
-            return Err(format!("Missing column #0 (`Sequence-Name`) in line #{i} {line}").into());
-        };
-        let mut alt_names = vec![];
-
-        // Accessions:
-        // GenBank, column #4
-        if let Some(&gen_bank) = fields.get(4) {
-            if gen_bank != "na" {
-                alt_names.push(gen_bank);
-            }
-        };
-        // RefSeq, column #6
-        if let Some(&refseq) = fields.get(6) {
-            if refseq != "na" {
-                alt_names.push(refseq);
-            }
-        };
-        // UCSC, column #9
-        if let Some(&ucsc) = fields.get(9) {
-            if ucsc != "na" {
-                alt_names.push(ucsc);
-            }
-        };
-
-        // Length
-        let length = if let Some(&l) = fields.get(8) {
-            match l.parse() {
-                Ok(length) => length,
-                Err(_) => {
-                    return Err(format!("Cannot parse field #8 {l:?} into contig length").into())
-                }
-            }
-        } else {
-            return Err(
-                format!("Missing column #8 (`Sequence-Length`) in line #{i} {line}").into(),
-            );
-        };
-
-        match Contig::new(name, &alt_names, length) {
-            Some(contig) => contigs.push(contig),
-            None => return Err("Cannot parse contig".into()),
-        };
     }
 
     Ok(GenomeBuild::new(id, contigs))
+}
+
+/// Represents the reasons for which parsing of the genome assembly report can fail.
+///
+/// The reasons include I/O error of the underlying [`BufRead`]
+/// (reported as [`GenomeAssemblyParseError::IoError`]) and parsing of the assembly report lines
+/// (reported as [`GenomeAssemblyParseError::AssemblyReportLineParseError`]) with one of the following:
+/// * Less than 10 columns in the assembly report data line (`Sequence-Name`)
+/// * Missing/unparsable column `9` (`Sequence-Length`)
+/// * Sequence length being negative (should not really happen)
+#[derive(Debug, Error)]
+pub enum GenomeAssemblyParseError {
+    #[error("I/O error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("Line #{0}: {1}")]
+    AssemblyReportLineParseError(usize, Box<dyn std::error::Error>),
+}
+
+struct GenomeAssemblyRecord<'a> {
+    fields: Vec<&'a str>,
+}
+
+const SEQ_NAME_COL_IDX: usize = 0;
+const GENBANK_ACC_COL_IDX: usize = 4;
+const REFSEQ_ACC_COL_IDX: usize = 6;
+const UCSC_ACC_COL_IDX: usize = 9;
+const CONTIG_LEN_COL_IDX: usize = 8;
+
+impl<'a> GenomeAssemblyRecord<'a> {
+    fn sequence_name(&self) -> &str {
+        self.fields.get(SEQ_NAME_COL_IDX).unwrap()
+    }
+
+    fn genbank_acc(&self) -> Option<&str> {
+        self.fields
+            .get(GENBANK_ACC_COL_IDX)
+            .filter(|x| **x != "na")
+            .copied()
+    }
+
+    fn refseq_acc(&self) -> Option<&str> {
+        self.fields
+            .get(REFSEQ_ACC_COL_IDX)
+            .filter(|x| **x != "na")
+            .copied()
+    }
+
+    fn ucsc_acc(&self) -> Option<&str> {
+        self.fields
+            .get(UCSC_ACC_COL_IDX)
+            .filter(|x| **x != "na")
+            .copied()
+    }
+
+    fn length(&self) -> &str {
+        self.fields
+            .get(CONTIG_LEN_COL_IDX)
+            .expect("We checked that there are at least 10 fields in the record!")
+    }
+}
+
+impl<'a> TryFrom<Vec<&'a str>> for GenomeAssemblyRecord<'a> {
+    type Error = &'static str;
+
+    fn try_from(fields: Vec<&'a str>) -> Result<Self, Self::Error> {
+        if fields.len() < 10 {
+            Err("less than 10 fields in the line")
+        } else {
+            Ok(GenomeAssemblyRecord { fields })
+        }
+    }
+}
+
+impl<'a> TryFrom<GenomeAssemblyRecord<'a>> for Contig {
+    type Error = ParseIntError;
+    fn try_from(value: GenomeAssemblyRecord<'a>) -> Result<Self, Self::Error> {
+        Ok(Contig {
+            name: value.sequence_name().to_string(),
+            genbank_name: value.genbank_acc().map(ToString::to_string),
+            refseq_name: value.refseq_acc().map(ToString::to_string),
+            ucsc_name: value.ucsc_acc().map(ToString::to_string),
+            length: value.length().parse()?,
+        })
+    }
 }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -5,22 +5,20 @@
 /* ***************************************************************************************************************** *
  *                                               Contig
  * ***************************************************************************************************************** */
-
+use std::convert::Infallible;
 use std::str::FromStr;
 
-use num_traits::{CheckedSub, Zero};
-
 /// The contig data, such as identifiers and its length.
-///
-/// `C` is the data type to represent the number of contig's base pairs.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Contig<C> {
-    name: String,
-    alt_names: Vec<String>,
-    length: C,
+pub struct Contig {
+    pub(crate) name: String,
+    pub(crate) genbank_name: Option<String>,
+    pub(crate) refseq_name: Option<String>,
+    pub(crate) ucsc_name: Option<String>,
+    pub(crate) length: u32,
 }
 
-impl<C> Contig<C> {
+impl Contig {
     /// Get the main name of the contig (e.g. `10`, `X`, `MT`).
     pub fn name(&self) -> &str {
         &self.name
@@ -29,64 +27,162 @@ impl<C> Contig<C> {
     /// Get the alternative contig identifiers.
     ///
     /// For instance, `CM000686.2`, `NC_000024.10`, and `chrY` for chromosome `Y`.
+    ///
+    /// # Example
+    /// ```
+    /// use dabuild::Contig;
+    ///
+    /// let contig = Contig::new("Y", &["CM000686.2", "NC_000024.10", "chrY"], 57_227_415).expect("The contig data are valid");
+    ///
+    /// let alt_names: Vec<_> = contig.alt_names().collect();
+    /// assert_eq!(&alt_names, &["CM000686.2", "NC_000024.10", "chrY"]);
     pub fn alt_names(&self) -> impl Iterator<Item = &str> {
-        self.alt_names.iter().map(AsRef::as_ref)
+        std::iter::once(&self.genbank_name)
+            .chain(std::iter::once(&self.refseq_name))
+            .chain(std::iter::once(&self.ucsc_name))
+            .flatten()
+            .map(AsRef::as_ref)
     }
 
-    /// Get the number of bases of the contig
-    pub fn length(&self) -> &C {
-        &self.length
+    /// Get the GenBank contig identifier, if it exists.
+    ///
+    /// For instance, `CM000686.2` for chromosome `Y` of the *GRCh38.p13* assembly.
+    ///
+    /// # Example
+    /// ```
+    /// use dabuild::Contig;
+    ///
+    /// let contig = Contig::new("Y", &["CM000686.2", "NC_000024.10", "chrY"], 57_227_415).expect("The contig data are valid");
+    ///
+    /// assert_eq!(contig.genbank_name(), Some("CM000686.2"));
+    /// ```
+    pub fn genbank_name(&self) -> Option<&str> {
+        self.genbank_name.as_deref()
+    }
+
+    /// Get the RefSeq contig identifier, if it exists.
+    ///
+    /// For instance, `NC_000024.10` for chromosome `Y` of the *GRCh38.p13* assembly.
+    ///
+    /// # Example
+    /// ```
+    /// use dabuild::Contig;
+    ///
+    /// let contig = Contig::new("Y", &["CM000686.2", "NC_000024.10", "chrY"], 57_227_415).expect("The contig data are valid");
+    ///
+    /// assert_eq!(contig.refseq_name(), Some("NC_000024.10"));
+    /// ```
+    pub fn refseq_name(&self) -> Option<&str> {
+        self.refseq_name.as_deref()
+    }
+
+    /// Get the UCSC contig identifier, if it exists.
+    ///
+    /// For instance, `chrY` for chromosome `Y` of the *GRCh38.p13* assembly.
+    ///
+    /// # Example
+    /// ```
+    /// use dabuild::Contig;
+    ///
+    /// let contig = Contig::new("Y", &["CM000686.2", "NC_000024.10", "chrY"], 57_227_415).expect("The contig data are valid");
+    ///
+    /// assert_eq!(contig.ucsc_name(), Some("chrY"));
+    /// ```
+    pub fn ucsc_name(&self) -> Option<&str> {
+        self.ucsc_name.as_deref()
+    }
+
+    /// Get the number of bases of the contig.
+    pub fn length(&self) -> u32 {
+        self.length
     }
 
     /// Transpose coordinate on a double-stranded sequence to the opposite strand.
     ///
-    /// Returns `None` if the operation would lead to underflow.
-    pub fn transpose_coordinate(&self, other: &C) -> Option<C>
-    where
-        C: CheckedSub,
-    {
+    /// Returns `None` if the operation would lead to overflow.
+    pub fn transpose_coordinate(&self, other: u32) -> Option<u32> {
         self.length.checked_sub(other)
     }
-}
 
-impl<C> Contig<C>
-where
-    C: Zero + PartialOrd,
-{
-    pub fn new<T, U>(name: T, alt_names: &[U], length: C) -> Option<Self>
-    where
-        T: ToString,
-        U: ToString,
-    {
-        if length < C::zero() {
-            None
-        } else {
-            Some(Self {
-                name: name.to_string(),
-                alt_names: alt_names.iter().map(ToString::to_string).collect(),
-                length,
-            })
-        }
+    /// Create a Contig from `name`, the alternative names, and its length.
+    ///
+    /// # Example
+    ///
+    /// Create a `Contig` with fields from the GRC assembly report:
+    ///
+    /// ```
+    /// use dabuild::Contig;
+    ///
+    /// let contig = Contig::new("Y", &["CM000686.2", "NC_000024.10", "chrY"], 57_227_415);
+    ///
+    /// assert!(contig.is_some());
+    /// let contig = contig.unwrap();
+    /// assert_eq!(contig.name(), "Y");
+    /// assert_eq!(contig.genbank_name(), Some("CM000686.2"));
+    /// ```
+    ///
+    /// Create a `Contig` with sequence name and UCSC accession:
+    ///
+    /// ```
+    /// use dabuild::Contig;
+    ///
+    /// let contig = Contig::new("Y", &["na", "", "chrY"], 57_227_415);
+    ///
+    /// assert!(contig.is_some());
+    ///
+    /// let contig = contig.unwrap();
+    /// assert_eq!(contig.name(), "Y");
+    /// assert!(contig.genbank_name().is_none());
+    /// assert!(contig.refseq_name().is_none());
+    /// assert_eq!(contig.ucsc_name(), Some("chrY"));
+    /// ```
+    ///
+    /// The `new` expects `alt_names` with three items that correspond to:
+    /// * GenBank accession
+    /// * RefSeq accession
+    /// * UCSC accession
+    ///
+    /// An accession equaling to an empty string or `"na"` is filtered out.
+    pub fn new(name: impl ToString, alt_names: &[impl ToString], length: u32) -> Option<Self> {
+        const NON_EMPTY_NON_NA_STRING: fn(&String) -> bool = |v| !v.is_empty() && v != "na";
+
+        Some(Self {
+            name: name.to_string(),
+            #[allow(clippy::get_first)]
+            genbank_name: alt_names
+                .get(0)
+                .map(ToString::to_string)
+                .filter(NON_EMPTY_NON_NA_STRING),
+            refseq_name: alt_names
+                .get(1)
+                .map(ToString::to_string)
+                .filter(NON_EMPTY_NON_NA_STRING),
+            ucsc_name: alt_names
+                .get(2)
+                .map(ToString::to_string)
+                .filter(NON_EMPTY_NON_NA_STRING),
+            length,
+        })
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod contig_tests {
     use super::Contig;
 
     #[test]
     fn test_transpose_coordinate() {
-        let contig = Contig::new("X", &["Y"], 10u8).unwrap();
+        let contig = Contig::new("X", &["Y"], 10).unwrap();
 
-        assert_eq!(contig.transpose_coordinate(&10).unwrap(), 0u8);
-        assert_eq!(contig.transpose_coordinate(&8).unwrap(), 2u8);
+        assert_eq!(contig.transpose_coordinate(10).unwrap(), 0);
+        assert_eq!(contig.transpose_coordinate(8).unwrap(), 2);
     }
 
     #[test]
     fn test_transpose_coordinate_panics() {
-        let contig = Contig::new("X", &["Y"], 10u8).unwrap();
+        let contig = Contig::new("X", &["Y"], 10).unwrap();
 
-        assert!(contig.transpose_coordinate(&11).is_none())
+        assert!(contig.transpose_coordinate(11).is_none())
     }
 }
 
@@ -106,7 +202,7 @@ pub struct GenomeBuildIdentifier {
 ///
 /// Infallible.
 impl FromStr for GenomeBuildIdentifier {
-    type Err = String;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(GenomeBuildIdentifier {
@@ -151,15 +247,15 @@ impl GenomeBuildIdentifier {
 
 /// Genome build includes the contigs and genome build metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GenomeBuild<C> {
+pub struct GenomeBuild {
     id: GenomeBuildIdentifier,
-    contigs: Vec<Contig<C>>,
+    contigs: Vec<Contig>,
 }
 
-impl<C> GenomeBuild<C> {
+impl GenomeBuild {
     pub fn new<I>(id: GenomeBuildIdentifier, contigs: I) -> Self
     where
-        I: IntoIterator<Item = Contig<C>>,
+        I: IntoIterator<Item = Contig>,
     {
         let mut contigs: Vec<_> = contigs.into_iter().collect();
         contigs.sort_by(|l, r| l.name().cmp(r.name()));
@@ -172,11 +268,11 @@ impl<C> GenomeBuild<C> {
     }
 
     /// Get an iterator with all contigs.
-    pub fn contigs(&self) -> impl Iterator<Item = &Contig<C>> {
+    pub fn contigs(&self) -> impl Iterator<Item = &Contig> {
         self.contigs.iter()
     }
 
-    pub fn contig_by_name(&self, name: &str) -> Option<&Contig<C>> {
+    pub fn contig_by_name(&self, name: &str) -> Option<&Contig> {
         self.contigs
             .iter()
             .find(|&c| c.name().eq(name) || c.alt_names().any(|alt_name| alt_name.eq(name)))

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -190,7 +190,7 @@ mod contig_tests {
  *                                               Genome Build
  * ***************************************************************************************************************** */
 
-/// Includes information to identify a genome build.
+/// All information needed to identify a genome build.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenomeBuildIdentifier {
     major_assembly: String,
@@ -245,7 +245,7 @@ impl GenomeBuildIdentifier {
     }
 }
 
-/// Genome build includes the contigs and genome build metadata.
+/// Genome build includes the contigs and the genome build metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenomeBuild {
     id: GenomeBuildIdentifier,

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -233,13 +233,31 @@ where
 }
 
 impl GenomeBuildIdentifier {
-    /// Get a `&str` with the major assembly identifier.
+    /// Get a [`&str`] with the major assembly identifier.
+    ///
+    /// ```
+    /// use dabuild::{GenomeBuild, GenomeBuildIdentifier};
+    /// use dabuild::builds::get_grch38_p13;
+    ///
+    /// let build: GenomeBuild = get_grch38_p13();
+    ///
+    /// assert_eq!(build.id().major_assembly(), "GRCh38");
+    /// ```
     pub fn major_assembly(&self) -> &str {
         &self.major_assembly
     }
 
     /// Get the patch identifier
-    /// or `None` if the build identifier has no patch info.
+    /// or [`None`] if the build identifier has no patch info.
+    ///
+    /// ```
+    /// use dabuild::{GenomeBuild, GenomeBuildIdentifier};
+    /// use dabuild::builds::get_grch38_p13;
+    ///
+    /// let build: GenomeBuild = get_grch38_p13();
+    ///
+    /// assert_eq!(build.id().patch(), Some("p13"));
+    /// ```
     pub fn patch(&self) -> Option<&str> {
         self.patch.as_deref()
     }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -44,7 +44,7 @@ impl Contig {
             .map(AsRef::as_ref)
     }
 
-    /// Get the GenBank contig identifier, if it exists.
+    /// Get the GenBank contig identifier, if available.
     ///
     /// For instance, `CM000686.2` for chromosome `Y` of the *GRCh38.p13* assembly.
     ///
@@ -60,7 +60,7 @@ impl Contig {
         self.genbank_name.as_deref()
     }
 
-    /// Get the RefSeq contig identifier, if it exists.
+    /// Get the RefSeq contig identifier, if available.
     ///
     /// For instance, `NC_000024.10` for chromosome `Y` of the *GRCh38.p13* assembly.
     ///
@@ -76,7 +76,7 @@ impl Contig {
         self.refseq_name.as_deref()
     }
 
-    /// Get the UCSC contig identifier, if it exists.
+    /// Get the UCSC contig identifier, if available.
     ///
     /// For instance, `chrY` for chromosome `Y` of the *GRCh38.p13* assembly.
     ///
@@ -92,14 +92,14 @@ impl Contig {
         self.ucsc_name.as_deref()
     }
 
-    /// Get the number of bases of the contig.
+    /// Get the number of bases of the contig, a.k.a. its length.
     pub fn length(&self) -> u32 {
         self.length
     }
 
     /// Transpose coordinate on a double-stranded sequence to the opposite strand.
     ///
-    /// Returns `None` if the operation would lead to overflow.
+    /// Returns `None` if the operation would lead to an overflow.
     pub fn transpose_coordinate(&self, other: u32) -> Option<u32> {
         self.length.checked_sub(other)
     }
@@ -272,6 +272,32 @@ impl GenomeBuild {
         self.contigs.iter()
     }
 
+    /// Retrieve a [`Contig`] by its name or [`None`] if no such [`Contig`] can be found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dabuild::{GenomeBuild, GenomeBuildIdentifier};
+    /// use dabuild::builds::get_grch38_p13;
+    ///
+    /// let build: GenomeBuild = get_grch38_p13();
+    ///
+    /// // Query by a contig name ...
+    /// let chrY = build.contig_by_name("Y").unwrap();
+    /// assert_eq!(chrY.name(), "Y");
+    ///
+    /// // ... or by GenBank accession ...
+    /// let chrY = build.contig_by_name("CM000686.2").unwrap();
+    /// assert_eq!(chrY.genbank_name(), Some("CM000686.2"));
+    ///
+    /// // ... or by RefSeq accession ...
+    /// let chrY = build.contig_by_name("NC_000024.10").unwrap();
+    /// assert_eq!(chrY.refseq_name(), Some("NC_000024.10"));
+    ///
+    /// // ... or by UCSC accession.
+    /// let chrY = build.contig_by_name("chrY").unwrap();
+    /// assert_eq!(chrY.ucsc_name(), Some("chrY"));
+    /// ```
     pub fn contig_by_name(&self, name: &str) -> Option<&Contig> {
         self.contigs
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! # dabuild
 //!
-//! `dabuild` provides you with genome build metadata.
+//! `dabuild` simplifies the access to genome build metadata, including its accession, version,
+//! and contigs.
 //!
 //! ## Examples
 //!
@@ -23,7 +24,7 @@
 //! use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! use dabuild::builds::get_grch38_p13;
 //!
-//! let build: GenomeBuild<u32> = get_grch38_p13();
+//! let build: GenomeBuild = get_grch38_p13();
 //! ```
 //!
 //! ### Check build identifiers
@@ -33,7 +34,7 @@
 //! ```rust
 //! # use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! # use dabuild::builds::get_grch38_p13;
-//! # let build: GenomeBuild<u32> = get_grch38_p13();
+//! # let build: GenomeBuild = get_grch38_p13();
 //!
 //! assert_eq!(build.id().major_assembly(), "GRCh38");
 //! assert_eq!(build.id().patch(), Some("p13"));
@@ -48,7 +49,7 @@
 //! ```rust
 //! # use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! # use dabuild::builds::get_grch38_p13;
-//! # let build: GenomeBuild<u32> = get_grch38_p13();
+//! # let build: GenomeBuild = get_grch38_p13();
 //!
 //! let count = build.contigs().count();
 //! assert_eq!(count, 640);
@@ -59,7 +60,7 @@
 //! ```rust
 //! # use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! # use dabuild::builds::get_grch38_p13;
-//! # let build: GenomeBuild<u32> = get_grch38_p13();
+//! # let build: GenomeBuild = get_grch38_p13();
 //!
 //! // Query by name ...
 //! let y = build.contig_by_name("Y");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! ### Load genome build
 //!
-//! The [`builds`] module provides several bundled builds.
-//! Alternatively, you can load a build from an assembly report.
+//! The [`builds`] module provides several bundled genome builds.
+//! Alternatively, you can load a genome build from a Genome Reference Consortium's (GRC) assembly report.
 //!
 //! See the [`builds`] documentation for more info.
 //!
@@ -35,7 +35,6 @@
 //! # use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! # use dabuild::builds::get_grch38_p13;
 //! # let build: GenomeBuild = get_grch38_p13();
-//!
 //! assert_eq!(build.id().major_assembly(), "GRCh38");
 //! assert_eq!(build.id().patch(), Some("p13"));
 //! ```
@@ -50,7 +49,6 @@
 //! # use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! # use dabuild::builds::get_grch38_p13;
 //! # let build: GenomeBuild = get_grch38_p13();
-//!
 //! let count = build.contigs().count();
 //! assert_eq!(count, 640);
 //! ```
@@ -61,20 +59,19 @@
 //! # use dabuild::{GenomeBuild, GenomeBuildIdentifier};
 //! # use dabuild::builds::get_grch38_p13;
 //! # let build: GenomeBuild = get_grch38_p13();
-//!
 //! // Query by name ...
 //! let y = build.contig_by_name("Y");
 //! assert!(y.is_some());
 //!
-//! /// ... or GenBank accession ...
+//! // ... or by the GenBank accession ...
 //! let y = build.contig_by_name("CM000686.2");
 //! assert!(y.is_some());
 //!
-//! /// ... or RefSeq accession ...
+//! // ... or by the RefSeq accession ...
 //! let y = build.contig_by_name("NC_000024.10");
 //! assert!(y.is_some());
 //!
-//! /// ... or UCSC identifier.
+//! // ... or by the UCSC identifier.
 //! let y = build.contig_by_name("chrY");
 //! assert!(y.is_some());
 //! ```

--- a/tests/test_builds.rs
+++ b/tests/test_builds.rs
@@ -4,7 +4,7 @@ use dabuild::{builds::*, GenomeBuild, GenomeBuildIdentifier};
 
 #[test]
 fn grch38_p13() {
-    let build = get_grch38_p13::<usize>();
+    let build = get_grch38_p13();
 
     assert_eq!(build.id().major_assembly(), "GRCh38");
     assert_eq!(build.id().patch(), Some("p13"));
@@ -22,17 +22,17 @@ fn grch38_p13() {
         .iter()
         .all(|x| alt.contains(x)));
 
-    assert_eq!(contig.length(), &248_956_422usize);
+    assert_eq!(contig.length(), 248_956_422);
 }
 
 #[test]
 fn test_parse_assembly_report() -> Result<(), Box<dyn Error>> {
     let path = "data/GCF_000001635.27_GRCm39_assembly_report.txt";
     let read = BufReader::new(File::open(path)?);
-    let build = parse_assembly_report(GenomeBuildIdentifier::from_str("GRCm39").unwrap(), read);
+    let build = parse_assembly_report(GenomeBuildIdentifier::from_str("GRCm39")?, read);
 
     assert!(build.is_ok());
-    let build: GenomeBuild<u32> = build?;
+    let build: GenomeBuild = build?;
 
     assert_eq!(build.id().major_assembly(), "GRCm39");
     assert_eq!(build.id().patch(), None);
@@ -50,7 +50,7 @@ fn test_parse_assembly_report() -> Result<(), Box<dyn Error>> {
         .iter()
         .all(|x| alt.contains(x)));
 
-    assert_eq!(contig.length(), &91_455_967u32);
+    assert_eq!(contig.length(), 91_455_967);
 
     Ok(())
 }

--- a/tests/test_genome.rs
+++ b/tests/test_genome.rs
@@ -2,7 +2,7 @@ use dabuild::Contig;
 
 #[test]
 fn contig_basics() {
-    let contig = Contig::new("1", &["CM000663.2", "NC_000001.11", "chr1"], 10u8).unwrap();
+    let contig = Contig::new("1", &["CM000663.2", "NC_000001.11", "chr1"], 10).unwrap();
 
     assert_eq!(contig.name(), "1");
     assert_eq!(contig.alt_names().count(), 3);
@@ -10,5 +10,5 @@ fn contig_basics() {
         contig.alt_names().collect::<Vec<_>>(),
         vec!["CM000663.2", "NC_000001.11", "chr1"]
     );
-    assert_eq!(contig.length(), &10u8);
+    assert_eq!(contig.length(), 10);
 }


### PR DESCRIPTION
Remove generics from `Contig` and `GenomeBuild`. Expose alternate contig identifiers.

**BREAKING CHANGES!**